### PR TITLE
Possibilidade de declarar um Exception no retorno de um handler

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -39,7 +39,7 @@ async def users_2() -> HTTP[Status.ACCEPTED, UserResource]:
 @content_negotiation
 async def accounts(
     request: web.Request
-) -> Union[HTTP[Status.OK, Account], HTTP[Status.NOT_FOUND, NotFoundException]]:
+) -> Union[HTTP[Status.OK, Account], NotFoundException]:
     what = request.match_info["what"]
     if what == "e":
         raise NotFoundException(error="Resource not found")

--- a/app/app.py
+++ b/app/app.py
@@ -5,6 +5,8 @@ from aiohttp import web
 
 from app.content import content_negotiation
 from app.http.status import Status
+from app.resources.account import Account
+from app.resources.base import NotFoundException
 from app.resources.user import UserResource
 from app.types.http import HTTP
 from asyncworker import App, RouteTypes
@@ -31,3 +33,18 @@ async def users() -> UserResource:
 @content_negotiation
 async def users_2() -> HTTP[Status.ACCEPTED, UserResource]:
     return UserResource(id=2, name="Other User", phone="+5511...")
+
+
+@app.http(["/accounts/{what}"], methods=["GET"])
+@content_negotiation
+async def accounts(
+    request: web.Request
+) -> Union[HTTP[Status.OK, Account], HTTP[Status.NOT_FOUND, NotFoundException]]:
+    what = request.match_info["what"]
+    if what == "e":
+        raise NotFoundException(error="Resource not found")
+
+    if what == "u":
+        v = 1 / 0
+
+    return Account(id=1, name="Account")

--- a/app/content.py
+++ b/app/content.py
@@ -29,8 +29,7 @@ def content_negotiation(handler):
         try:
             result = await call_http_handler(request, handler)
         except HTTPException as http_exc:
-            status_code = types_dict.get(http_exc.__class__, HTTPStatus.OK)
-            return web.json_response(http_exc.dict(), status=status_code)
+            return web.json_response(http_exc.dict(), status=http_exc.status)
 
         if isinstance(result, Resource):
             status_code = types_dict.get(result.__class__, HTTPStatus.OK)

--- a/app/resources/account.py
+++ b/app/resources/account.py
@@ -1,0 +1,6 @@
+from app.resources.base import Resource
+
+
+class Account(Resource):
+    id: int
+    name: str

--- a/app/resources/base.py
+++ b/app/resources/base.py
@@ -1,4 +1,5 @@
 import sys
+from http import HTTPStatus
 from typing import Dict, Type, Generic, TypeVar
 
 from pydantic import BaseModel
@@ -29,6 +30,7 @@ class Resource(BaseModel):
 
 
 class HTTPException(Exception):
+    status = -1
 
     error: str
 
@@ -40,4 +42,4 @@ class HTTPException(Exception):
 
 
 class NotFoundException(HTTPException):
-    pass
+    status = HTTPStatus.NOT_FOUND

--- a/app/resources/base.py
+++ b/app/resources/base.py
@@ -26,3 +26,18 @@ class Resource(BaseModel):
     @staticmethod
     def media_types() -> Dict[str, Type[VersionedResource]]:
         return {}
+
+
+class HTTPException(Exception):
+
+    error: str
+
+    def __init__(self, error: str) -> None:
+        self.error = error
+
+    def dict(self):
+        return {"error": self.error}
+
+
+class NotFoundException(HTTPException):
+    pass

--- a/app/types/http.py
+++ b/app/types/http.py
@@ -1,7 +1,7 @@
 from typing import Generic, TypeVar, Union
 
 from app.http.status import HTTPStatus
-from app.resources.base import Resource
+from app.resources.base import Resource, NotFoundException
 
 Status = TypeVar("Status", bound=HTTPStatus)
 _Resource = TypeVar("_Resource", bound=Resource)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,3 +71,24 @@ class AppTest(TestCase):
             self.assertEqual(
                 {"id": 2, "name": "Other User", "phone": "+5511..."}, resp_data
             )
+
+    async def test_accounts_or_user_resource_with_status_code(self):
+        async with self.client_context as client:
+            resp = await client.get("/accounts/1")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+            resp_data = await resp.json()
+
+            self.assertEqual({"id": 1, "name": "Account"}, resp_data)
+
+    async def test_accounts_raise_not_found_exception(self):
+        async with self.client_context as client:
+            resp = await client.get("/accounts/e")
+            self.assertEqual(HTTPStatus.NOT_FOUND, resp.status)
+            resp_data = await resp.json()
+
+            self.assertEqual({"error": "Resource not found"}, resp_data)
+
+    async def test_accounts_raise_uncaught_exception(self):
+        async with self.client_context as client:
+            resp = await client.get("/accounts/u")
+            self.assertEqual(HTTPStatus.INTERNAL_SERVER_ERROR, resp.status)


### PR DESCRIPTION
Podemos também ter uma Exception como um possível "valor de retorno" do
handler. Aqui temos algumas escolhas:

O tipo `HTTP[Status, _Resource]` limita o parametro `_Resource` a
**sempre** ser subclasse do `Resource` base, o que é bom. Assim o
próprio linter vai perceber se o retonro do handler não estiver de
acordo com a interface proposta pelo `Resource`.

No entanto podemos querer também mapear uma posspivel Exception, que
também deve ser subclasse de uma "BaseException" fornecida pelo
asyncworker.

Aqui, talvez, seja melhor termos um segundo tipo: `HTTPException[Status,
_Exception]` nos mesmos moldes do `HTTP[Status, _Resource]`.


Refs #3 