### PR TITLE
Feature/multi charset resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.mypy/

--- a/app/app.py
+++ b/app/app.py
@@ -65,13 +65,5 @@ async def charsets(request: web.Request) -> CharsetResource:
     """
     body = await request.json()
     string = body["string"]
-    d = {"string": string}
-    res = json.dumps(d)
 
-    # return CharsetResource(string=string)
-    return web.Response(
-        body=res.encode("utf-16"),
-        headers={
-            "Content-Type": "application/vnd.charset.v1+json;charset=utf-16"
-        },
-    )
+    return CharsetResource(string=string)

--- a/app/resources/account.py
+++ b/app/resources/account.py
@@ -1,6 +1,11 @@
-from app.resources.base import Resource
+import json
+
+from app.resources.base import Resource, MediaType
 
 
 class Account(Resource):
     id: int
     name: str
+
+    def serialize(self, media_type: MediaType) -> bytes:
+        return json.dumps(self.dict()).encode("utf-8")

--- a/app/resources/base.py
+++ b/app/resources/base.py
@@ -1,15 +1,44 @@
+import abc
 import sys
+from enum import Enum
 from http import HTTPStatus
-from typing import Dict, Type, Generic, TypeVar
+from typing import Dict, Type, Generic, Optional, List
 
 from pydantic import BaseModel
-from pydantic.generics import GenericModel
 
-T = TypeVar("T")
+
+class Charset(str, Enum):
+    UTF8 = "utf-8"
+    UTF16 = "utf-16"
+    UTF32 = "utf-32"
+    USASCII = "us-ascii"
+    LATIN1 = "latin-1"
+
+
+class MediaType(BaseModel):
+    type: str = "application"
+    facet: Optional[str]
+    subtype: str = "json"
+    charset: Charset = Charset.UTF8
+    format: str = "json"
+
+    @staticmethod
+    def parse(media_type: str) -> "MediaType":
+        type = media_type.split("/")[0]
+        subtype = media_type.split("/")[1].split("+")[0]
+        charset = Charset.UTF16 if "utf-16" in media_type else Charset.UTF8
+        return MediaType(subtype=subtype, charset=charset, type=type)
+
+
+class SerializableResource(abc.ABC):
+    @abc.abstractmethod
+    def serialize(self, media_type: MediaType) -> bytes:
+        raise NotImplementedError
+
 
 if sys.version_info[1] >= 7:
 
-    class VersionedResource(GenericModel, Generic[T]):
+    class VersionedResource(Generic[T], SerializableResource):
         @staticmethod
         def transform_from(base: T) -> "VersionedResource":
             raise NotImplementedError
@@ -23,10 +52,19 @@ else:
             raise NotImplementedError
 
 
-class Resource(BaseModel):
+class Resource(BaseModel, SerializableResource):
     @staticmethod
     def media_types() -> Dict[str, Type[VersionedResource]]:
         return {}
+
+
+class VersionedResourceSpec:
+    charsets: List[Charset]
+    resource: VersionedResource
+
+    def __init__(self, charsets, resource) -> None:
+        self.charsets = charsets
+        self.resource = resource
 
 
 class HTTPException(Exception):

--- a/app/resources/charset.py
+++ b/app/resources/charset.py
@@ -1,0 +1,5 @@
+from app.resources.base import Resource
+
+
+class CharsetResource(Resource):
+    string: str

--- a/app/resources/charset.py
+++ b/app/resources/charset.py
@@ -1,5 +1,37 @@
-from app.resources.base import Resource
+import json
+
+from pydantic import BaseModel
+
+from app.resources.base import (
+    Resource,
+    MediaType,
+    VersionedResource,
+    Charset,
+    VersionedResourceSpec,
+)
 
 
 class CharsetResource(Resource):
     string: str
+
+    @staticmethod
+    def media_types():
+        return {
+            "application/vnd.charset.v1+json": VersionedResourceSpec(
+                charsets=[Charset.UTF16], resource=CharsetResourceV1
+            )
+        }
+
+    def serialize(self, media_type: MediaType) -> bytes:
+        raise NotImplementedError
+
+
+class CharsetResourceV1(BaseModel, VersionedResource[CharsetResource]):
+    other_string: str
+
+    @staticmethod
+    def transform_from(base: CharsetResource) -> "CharsetResourceV1":
+        return CharsetResourceV1(other_string=base.string)
+
+    def serialize(self, media_type: MediaType) -> bytes:
+        return json.dumps(self.dict()).encode(media_type.charset)

--- a/app/resources/user.py
+++ b/app/resources/user.py
@@ -1,10 +1,11 @@
+import json
 import sys
-from typing import Dict, Type
+from typing import Dict, Type, Any
 
 from pydantic import BaseModel
 from pydantic.generics import GenericModel
 
-from app.resources.base import Resource, VersionedResource
+from app.resources.base import Resource, VersionedResource, MediaType
 
 
 class UserResource(Resource):
@@ -19,22 +20,40 @@ class UserResource(Resource):
             "application/vnd.app.user.v2+json": UserResourceV2,
         }
 
+    def serialize(self, media_type: MediaType) -> bytes:
+        pass
+
+    def to_dict(self, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        return self.dict()
+
 
 if sys.version_info[1] >= 7:
 
-    class UserResourceV1(VersionedResource[UserResource]):
+    class UserResourceV1(BaseModel, VersionedResource[UserResource]):
         name: str
 
         @staticmethod
         def transform_from(base: UserResource) -> "UserResourceV1":
             return UserResourceV1(name=base.name)
 
-    class UserResourceV2(VersionedResource[UserResource]):
+        def serialize(self, media_type: MediaType) -> bytes:
+            return json.dumps(self.dict()).encode("utf-8")
+
+        def to_dict(self, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+            return self.dict()
+
+    class UserResourceV2(BaseModel, VersionedResource[UserResource]):
         phone: str
 
         @staticmethod
         def transform_from(base: UserResource) -> "UserResourceV2":
             return UserResourceV2(phone=base.phone)
+
+        def serialize(self, media_type: MediaType) -> bytes:
+            return json.dumps(self.dict()).encode("utf-8")
+
+        def to_dict(self, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+            return self.dict()
 
 
 else:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -92,3 +92,19 @@ class AppTest(TestCase):
         async with self.client_context as client:
             resp = await client.get("/accounts/u")
             self.assertEqual(HTTPStatus.INTERNAL_SERVER_ERROR, resp.status)
+
+    async def test_resource_specific_charset(self):
+        async with self.client_context as client:
+            value = "✓"
+            resp = await client.get(
+                "/charsets/1",
+                json={"string": value},
+                headers={
+                    "Accept": "application/vnd.charset.v1+json;charset=utf-16"
+                },
+            )
+            self.assertEqual(HTTPStatus.OK, resp.status)
+            resp_data = await resp.json()
+            self.assertEqual(
+                value.encode("utf-16"), resp_data["string"].encode("utf-16")
+            )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -95,16 +95,36 @@ class AppTest(TestCase):
 
     async def test_resource_specific_charset(self):
         async with self.client_context as client:
+            media_type = "application/vnd.charset.v1+json;charset=utf-16"
             value = "✓"
             resp = await client.get(
                 "/charsets/1",
                 json={"string": value},
-                headers={
-                    "Accept": "application/vnd.charset.v1+json;charset=utf-16"
-                },
+                headers={"Accept": media_type},
             )
             self.assertEqual(HTTPStatus.OK, resp.status)
+            self.assertEqual(media_type, resp.headers.get("Content-Type"))
             resp_data = await resp.json()
             self.assertEqual(
-                value.encode("utf-16"), resp_data["string"].encode("utf-16")
+                value.encode("utf-16"),
+                resp_data["other_string"].encode("utf-16"),
+            )
+
+    async def test_resource_unsuported_charset(self):
+        async with self.client_context as client:
+            charset = "utf-32"
+            media_type = "application/vnd.charset.v1+json"
+            value = "✓"
+            resp = await client.get(
+                "/charsets/1",
+                json={"string": value},
+                headers={"Accept": f"{media_type};charset={charset}"},
+            )
+            self.assertEqual(HTTPStatus.BAD_REQUEST, resp.status)
+            resp_data = await resp.json()
+            self.assertEqual(
+                {
+                    "error": f"Unsuported Charset for media_type {media_type}: {charset}"
+                },
+                resp_data,
             )


### PR DESCRIPTION
O que temos que observar aqui:

O retorno do método `media_types()` é incompatível com o que tínhamos
antes. Então precisamos pensar se vamos dar suporte a multi-charset
desde o início ou não.

Temos um dilema aqui:

 - Se os Resources básicos (`Resource` e `VersionedResource[T]`) já
 forem modelos pydantic podemos escrever um `serialize()` default que já
 assume `JSON+utf-8`. Mas isso (ser modelo pydantic) quebra a
 compatibilidade com py36, a não ser que deixems no código esse `if py37: ...`

 - Se não forem modelos pydantic, ficamos o mais retro-compatpiveis
 possível mas com o preço de forçar quem estiver usando o asyncowker a
 **sempre** ter que implementar o `serialize()` de todo mundo, mesmo que
 esse método tenha apenas: `return
 json.dumps(self.dict()).encode(charset)`.

 Para conseguirmos fugir disso, teríamos que criar um novo método que
 seria a transformação de um resource para `dict`. Não podemos fazer
 isso com um `def dict()` pois isso passaria a conflitar com o pydantic.
 Então penso em um `def to_dict(**params: Dict[str, Any])`. O problema
 disso é que quem escolher usar o pydantic como implementação de modelo
 terá que implementar em todos os seus resources Asyncworker um método:

```python
def to_dict(**params: Dict[str, Any]) -> Dict[str, Any]:
  return self.dict()
```

Talvez tenhamos uma outra possibilidade que é já ter no asyncworker uma
classe que "liga" um Resource genérico a um Modelo Pydantic, ou seja,
forneceria esse método `to_dict()` com essa implementação mostrada
acima.

Precisamos pensar nessas questões.